### PR TITLE
Add telescope default

### DIFF
--- a/lib/fitsblender/blendheaders.py
+++ b/lib/fitsblender/blendheaders.py
@@ -320,7 +320,7 @@ def get_blended_headers(inputs, verbose=False,extlist=['SCI','ERR','DQ']):
 
     phdrdict = collections.OrderedDict() #{}
     # Turn input filenames into a set of header objects
-    if isinstance(inputs[0], str):
+    if isinstance(inputs[0], basestring):
         hdrlist = [[],[],[],[]]
         for fname in inputs:
             #print 'Getting single template for : ',fname

--- a/lib/fitsblender/hst_header.rules
+++ b/lib/fitsblender/hst_header.rules
@@ -1,0 +1,514 @@
+!VERSION = 1.1
+!INSTRUMENT = ACS
+################################################################################
+#
+# Header keyword rules
+#
+# Columns definitions:
+#    Column 1: header keyword from input header or '<delete>'
+#    Column 2: [optional] name of table column for recording values from
+#              keyword specified in the first column from each input image
+#              =or= name of keyword to be updated in output image header
+#    Column 3: [optional] function to use to create output header value
+#              (output keyword name must be specified in second column)
+#
+# Any line that starts with '<delete>' indicates that that keyword
+# or set of keywords for that header section should be deleted from the
+# output header.
+#
+# Supported functions: first, last, min, max, mean, sum, stddev, multi
+#
+# Any keyword without a function will be copied to a table column with the
+# name given in the second column, or first column if only 1 column has been
+# specified.  These keywords will also be removed from the output header unless
+# another rule for the same keyword (1st column) has been specified with a
+# function named in the 3rd column.
+#
+# All keywords *not specified in this rules file* will be derived from the first
+# input image's header and used unchanged to create the final output header(s).
+# So, any keyword with a rule that adds that keyword to a table will be removed from
+# the output headers unless additional rules are provided to specify what values
+# should be kept in the header for that keyword.
+##
+# Final header output will use the same formatting and order of keywords defined
+# by the first image's headers.
+#
+# Rules for headers from all image extensions can be included in the same
+# file without regard for order, although keeping them organized by extension
+# makes the file easier to maintain and update.
+#
+# The order of the rules will determine the order of the columns in the
+# final output table. As a result, the rules for EXTNAME and EXTVER are
+# associated with ROOTNAME, rather than the SCI header, in order to make
+# rows of the table easier to identify.
+#
+# Comments appended to the end of a rule will be ignored when reading the
+# rules. All comments start with '#'.
+#
+#
+################################################################################
+#
+# Table Keyword Rules
+#
+################################################################################
+ROOTNAME
+EXTNAME
+EXTVER
+A_0_2
+A_0_3
+A_0_4
+A_1_1
+A_1_2
+A_1_3
+A_2_0
+A_2_1
+A_2_2
+A_3_0
+A_3_1
+A_4_0
+ACQNAME
+A_ORDER
+APERTURE
+ASN_ID
+ASN_MTYP
+ASN_TAB
+ATODCORR
+ATODGNA
+ATODGNB
+ATODGNC
+ATODGND
+ATODTAB
+B_0_2
+B_0_3
+B_0_4
+B_1_1
+B_1_2
+B_1_3
+B_2_0
+B_2_1
+B_2_2
+B_3_0
+B_3_1
+B_4_0
+BADINPDQ
+BIASCORR
+BIASFILE
+BIASLEVA
+BIASLEVB
+BIASLEVC
+BIASLEVD
+BINAXIS1
+BINAXIS2
+BITPIX
+BLEVCORR
+B_ORDER
+BPIXTAB
+BUNIT
+CAL_VER
+CBLKSIZ
+CCDAMP
+CCDCHIP
+CCDGAIN
+CCDOFSTA
+CCDOFSTB
+CCDOFSTC
+CCDOFSTD
+CCDTAB
+CD1_1
+CD1_2
+CD2_1
+CD2_2
+CENTERA1
+CENTERA2
+CFLTFILE
+COMPTAB
+COMPTYP
+CRCORR
+CRMASK
+CRPIX1
+CRPIX2
+CRRADIUS
+CRREJTAB
+CRSIGMAS
+CRSPLIT
+CRTHRESH
+CRVAL1
+CRVAL2
+CTE_NAME
+CTE_VER
+CTEDIR
+CTEIMAGE
+CTYPE1
+CTYPE2
+D2IMFILE
+DARKCORR
+DARKFILE
+DATE
+DATE-OBS
+DEC_APER
+DEC_TARG
+DETECTOR
+DFLTFILE
+DGEOFILE
+DIRIMAGE
+DQICORR
+DRIZCORR
+DRKCFILE
+EQUINOX
+ERRCNT
+EXPEND
+EXPFLAG
+EXPNAME
+EXPSCORR
+EXPSTART
+EXPTIME
+EXTEND
+FGSLOCK
+FILENAME
+FILETYPE
+FILLCNT
+FILTER1
+FILTER2
+FLASHCUR
+FLASHDUR
+FLASHSTA
+FLATCORR
+FLSHCORR
+FLSHFILE
+FW1ERROR
+FW1OFFST
+FW2ERROR
+FW2OFFST
+FWSERROR
+FWSOFFST
+GCOUNT
+GLINCORR
+GLOBLIM
+GLOBRATE
+GOODMAX
+GOODMEAN
+GOODMIN
+GRAPHTAB
+GYROMODE
+IDCSCALE
+IDCTAB
+IDCTHETA
+IDCV2REF
+IDCV3REF
+IMAGETYP
+IMPHTTAB
+INHERIT
+INITGUES
+INSTRUME
+JWROTYPE
+LFLGCORR
+LFLTFILE
+LINENUM
+LOSTPIX
+LRC_FAIL
+LRC_XSTS
+LRFWAVE
+LTM1_1
+LTM2_2
+LTV1
+LTV2
+MDECODT1
+MDECODT2
+MDRIZSKY
+MDRIZTAB
+MEANBLEV
+MEANDARK
+MEANEXP
+MEANFLSH
+MLINTAB
+MOFFSET1
+MOFFSET2
+MOONANGL
+MTFLAG
+NAXIS
+NAXIS1
+NAXIS2
+NCOMBINE
+NEXTEND
+NGOODPIX
+NPOLFILE
+NRPTEXP
+OBSMODE
+OBSTYPE
+OCD1_1
+OCD1_2
+OCD2_1
+OCD2_2
+OCRPIX1
+OCRPIX2
+OCRVAL1
+OCRVAL2
+OCTYPE1
+OCTYPE2
+OCX10
+OCX11
+OCY10
+OCY11
+ONAXIS1
+ONAXIS2
+OORIENTA
+OPUS_VER
+ORIENTAT
+ORIGIN
+OSCNTAB
+P1_ANGLE
+P1_CENTR
+P1_FRAME
+P1_LSPAC
+P1_NPTS
+P1_ORINT
+P1_PSPAC
+P1_PURPS
+P1_SHAPE
+PA_APER
+PATTERN1
+PATTSTEP
+PA_V3
+PCOUNT
+PCTECORR
+PCTEFRAC
+PCTENSMD
+PCTERNCL
+PCTESHFT
+PCTESMIT
+PCTETAB
+PFLTFILE
+PHOTBW
+PHOTCORR
+PHOTFLAM
+PHOTMODE
+PHOTPLAM
+PHOTTAB
+PHOTZPT
+PODPSFF
+POSTARG1
+POSTARG2
+PRIMESI
+PR_INV_F
+PR_INV_L
+PR_INV_M
+PROCTIME
+PROPAPER
+PROPOSID
+QUALCOM1
+QUALCOM2
+QUALCOM3
+QUALITY
+RA_APER
+RA_TARG
+READNSEA
+READNSEB
+READNSEC
+READNSED
+REFFRAME
+REJ_RATE
+RPTCORR
+SCALENSE
+SCLAMP
+SDQFLAGS
+SHADCORR
+SHADFILE
+SHUTRPOS
+SIMPLE
+SIZAXIS1
+SIZAXIS2
+SKYSUB
+SKYSUM
+SNRMAX
+SNRMEAN
+SNRMIN
+SOFTERRS
+SPOTTAB
+STATFLAG
+STDCFFF
+STDCFFP
+SUBARRAY
+SUN_ALT
+SUNANGLE
+TARGNAME
+TDDALPHA
+TDDBETA
+TELESCOP
+TIME-OBS
+T_SGSTAR
+VAFACTOR
+WCSAXES
+WCSCDATE
+WFCMPRSD
+WRTERR
+XTENSION
+#
+# WCS Related Keyword Rules
+#     These move any OPUS-generated WCS values to the table
+#
+WCSNAMEO
+WCSAXESO
+LONPOLEO
+LATPOLEO
+RESTFRQO
+RESTWAVO
+CD1_1O
+CD1_2O
+CD2_1O
+CD2_2O
+CDELT1O
+CDELT2O
+CRPIX1O
+CRPIX2O
+CRVAL1O
+CRVAL2O
+CTYPE1O
+CTYPE2O
+CUNIT1O
+CUNIT2O
+################################################################################
+#
+# Header Keyword Rules
+#
+################################################################################
+APERTURE  APERTURE  multi
+DETECTOR  DETECTOR  first
+EXPEND    EXPEND    max
+EXPSTART  EXPSTART  min
+EXPTIME   TEXPTIME  sum
+EXPTIME   EXPTIME   sum
+FILTER1   FILTER1   multi
+FILTER2   FILTER2   multi
+GOODMAX   GOODMAX   max
+GOODMEAN  GOODMEAN  mean
+GOODMIN   GOODMIN   min
+INHERIT   INHERIT   first # maintain IRAF compatibility
+INSTRUME  INSTRUME  first
+LRFWAVE   LRFWAVE   first
+NCOMBINE  NCOMBINE  sum
+MDRIZSKY  MDRIZSKY  mean
+PHOTBW    PHOTBW    mean
+PHOTFLAM  PHOTFLAM  mean
+PHOTMODE  PHOTMODE  first
+PHOTPLAM  PHOTPLAM  mean
+PHOTZPT   PHOTZPT   mean
+PROPOSID  PROPOSID  first
+SNRMAX    SNRMAX    max
+SNRMEAN   SNRMEAN   mean
+SNRMIN    SNRMIN    min
+TARGNAME  TARGNAME  first
+TELESCOP  TELESCOP  first
+### rules below were added 05Jun2012,in response to Dorothy Fraquelli guidance re: DADS
+ATODCORR  ATODCORR  multi
+ATODGNA   ATODGNA   first
+ATODGNB   ATODGNB   first
+ATODGNC   ATODGNC   first
+ATODGND   ATODGND   first
+ATODTAB   ATODTAB   multi
+BADINPDQ  BADINPDQ  sum
+BIASCORR  BIASCORR  multi
+BIASFILE  BIASFILE  multi
+BLEVCORR  BLEVCORR  multi
+BPIXTAB   BPIXTAB   multi
+CCDCHIP   CCDCHIP   first
+CCDGAIN   CCDGAIN   first
+CCDOFSTA  CCDOFSTA  first
+CCDOFSTB  CCDOFSTB  first
+CCDOFSTC  CCDOFSTC  first
+CCDOFSTD  CCDOFSTD  first
+CCDTAB      CCDTAB    multi
+CFLTFILE  CFLTFILE  multi
+COMPTAB   COMPTAB   multi
+CRCORR      CRCORR    multi
+CRMASK      CRMASK    first
+CRRADIUS  CRRADIUS  first
+CRREJTAB  CRREJTAB  multi
+CRSPLIT   CRSPLIT   first
+CRTHRESH  CRTHRESH  first
+CTEDIR      CTEDIR    multi
+CTEIMAGE  CTEIMAGE  first
+DARKCORR  DARKCORR  multi
+DARKFILE  DARKFILE  multi
+DATE-OBS  DATE-OBS  first
+DEC_APER  DEC_APER  first
+DFLTFILE  DFLTFILE  multi
+DGEOFILE  DGEOFILE  multi
+DIRIMAGE  DIRIMAGE  multi
+DQICORR   DQICORR   multi
+DRIZCORR  DRIZCORR  multi
+EXPFLAG   EXPFLAG   multi
+EXPSCORR  EXPSCORR  multi
+FGSLOCK   FGSLOCK   multi
+FLASHCUR  FLASHCUR  multi
+FLASHDUR  FLASHDUR  first
+FLASHSTA  FLASHSTA  first
+FLATCORR  FLATCORR  multi
+FLSHCORR  FLSHCORR  multi
+FLSHFILE  FLSHFILE  multi
+FW1ERROR  FW1ERROR  multi
+FW1OFFST  FW1OFFST  first
+FW2ERROR  FW2ERROR  multi
+FW2OFFST  FW2OFFST  first
+FWSERROR  FWSERROR  multi
+FWSOFFST  FWSOFFST  first
+GRAPHTAB  GRAPHTAB  multi
+GYROMODE  GYROMODE  multi
+IDCTAB      IDCTAB    multi
+IMAGETYP  IMAGETYP  first
+IMPHTTAB  IMPHTTAB  multi
+LFLGCORR  LFLGCORR  multi
+LFLTFILE  LFLTFILE  multi
+LTM1_1    LTM1_1    float_one
+LTM2_2    LTM2_2    float_one
+MDRIZTAB  MDRIZTAB  multi
+MEANEXP   MEANEXP   first
+MOONANGL  MOONANGL  first
+NRPTEXP   NRPTEXP   first
+OBSMODE   OBSMODE   multi
+OBSTYPE   OBSTYPE   first
+OSCNTAB   OSCNTAB   multi
+P1_ANGLE  P1_ANGLE  first
+P1_CENTR  P1_CENTR  multi
+P1_FRAME  P1_FRAME  multi
+P1_LSPAC  P1_LSPAC  first
+P1_NPTS   P1_NPTS   first
+P1_ORINT  P1_ORINT  first
+P1_PSPAC  P1_PSPAC  first
+P1_PURPS  P1_PURPS  multi
+P1_SHAPE  P1_SHAPE  multi
+P2_ANGLE  P2_ANGLE  first
+P2_CENTR  P2_CENTR  multi
+P2_FRAME  P2_FRAME  multi
+P2_LSPAC  P2_LSPAC  first
+P2_NPTS   P2_NPTS   first
+P2_ORINT  P2_ORINT  first
+P2_PSPAC  P2_PSPAC  first
+P2_PURPS  P2_PURPS  multi
+P2_SHAPE  P2_SHAPE  multi
+PATTERN1  PATTERN1  multi
+PATTERN2  PATTERN2  multi
+PATTSTEP  PATTSTEP  first
+PHOTCORR  PHOTCORR  multi
+PHOTTAB   PHOTTAB   multi
+POSTARG1  POSTARG1  first
+POSTARG2  POSTARG2  first
+PRIMESI   PRIMESI   multi
+PROPAPER  PROPAPER  multi
+RA_APER   RA_APER   first
+READNSEA  READNSEA  first
+READNSEB  READNSEB  first
+READNSEC  READNSEC  first
+READNSED  READNSED  first
+REJ_RATE  REJ_RATE  first
+SCALENSE  SCALENSE  first
+SCLAMP      SCLAMP    multi
+SHADCORR  SHADCORR  multi
+SHADFILE  SHADFILE  multi
+SHUTRPOS  SHUTRPOS  multi
+SKYSUB      SKYSUB    multi
+SKYSUM      SKYSUM    sum
+SPOTTAB   SPOTTAB   multi
+SUBARRAY  SUBARRAY  first
+SUNANGLE  SUNANGLE  first
+SUN_ALT   SUN_ALT   first
+WRTERR      WRTERR    multi

--- a/lib/fitsblender/jwst_header.rules
+++ b/lib/fitsblender/jwst_header.rules
@@ -1,0 +1,405 @@
+!VERSION = 1.1
+!INSTRUMENT = NIRSPEC
+################################################################################
+#
+# Header keyword rules
+#
+# Columns definitions:
+#    Column 1: header keyword from input header or '<delete>'
+#    Column 2: [optional] name of table column for recording values from
+#              keyword specified in the first column from each input image
+#              =or= name of keyword to be updated in output image header
+#    Column 3: [optional] function to use to create output header value
+#              (output keyword name must be specified in second column)
+#
+# Any line that starts with '<delete>' indicates that that keyword
+# or set of keywords for that header section should be deleted from the
+# output header.
+#
+# Supported functions: first, last, min, max, mean, sum, stddev, multi
+#
+# Any keyword without a function will be copied to a table column with the
+# name given in the second column, or first column if only 1 column has been
+# specified.  These keywords will also be removed from the output header unless
+# another rule for the same keyword (1st column) has been specified with a
+# function named in the 3rd column.
+#
+# All keywords *not specified in this rules file* will be derived from the first
+# input image's header and used unchanged to create the final output header(s).
+# So, any keyword with a rule that adds that keyword to a table will be removed from
+# the output headers unless additional rules are provided to specify what values
+# should be kept in the header for that keyword.
+##
+# Final header output will use the same formatting and order of keywords defined
+# by the first image's headers.
+#
+# Rules for headers from all image extensions can be included in the same
+# file without regard for order, although keeping them organized by extension
+# makes the file easier to maintain and update.
+#
+# The order of the rules will determine the order of the columns in the
+# final output table. As a result, the rules for EXTNAME and EXTVER are
+# associated with ROOTNAME, rather than the SCI header, in order to make
+# rows of the table easier to identify.
+#
+# Comments appended to the end of a rule will be ignored when reading the
+# rules. All comments start with '#'.
+#
+#
+################################################################################
+#
+# Table Keyword Rules
+#
+################################################################################
+#
+# JWST keywords
+#
+FILENAME
+DATE-OBS
+TIME-OBS
+EXPSTART
+EXPMID
+EXPEND
+TITLE
+PI_NAME
+CATEGORY
+SUBCAT
+SCICAT
+OBS_ID
+VISIT_ID
+PROGRAM
+OBSERVTN
+VISIT
+VISITGRP
+SEQ_ID
+ACT_ID
+APERNAME
+PA_APER
+SCA_APER
+WCSAXES
+CRPIX1
+CRPIX2
+CRVAL1
+CRVAL2
+CTYPE1
+CTYPE2
+CUNIT1
+CUNIT2
+CDELT1
+CDELT2
+PC1_1
+PC1_2
+PC2_1
+PC2_2
+DVA_RA
+DVA_DEC
+VA_SCALE
+EXPOSURE
+TEMPLATE
+OBSLABEL
+DATE
+ORIGIN
+TIMESYS
+FILETYPE
+SDP_VER
+PRD_VER
+CAL_VER
+CAL_SVN
+TELESCOP
+RADESYS
+TITLE
+PI_NAME
+CATEGORY
+SUBCAT
+SCICAT
+DATE-OBS
+TIME-OBS
+VISITYPE
+VSTSTART
+WFSVISIT
+NEXPOSUR
+INTARGET
+TARGOOPP
+TARGPROP
+TARGNAME
+TARGTYPE
+TARG_RA
+TARG_DEC
+TARGURA
+TARGUDEC
+PROP_RA
+PROP_DEC
+PROPEPOC
+INSTRUME
+DETECTOR
+MODULE
+CHANNEL
+FILTER
+PUPIL
+PILIN
+LAMP
+PNTG_SEQ
+EXPCOUNT
+EXP_TYPE
+READPATT
+NINTS
+NGROUPS
+NFRAMES
+GROUPGAP
+NSAMPLES
+TSAMPLE
+TFRAME
+TGROUP
+EFFINTTM
+EFFEXPTM
+CHRGTIME
+DURATION
+NRSTSTRT
+NRESETS
+ZEROFRAM
+DATAPROB
+SCA_NUM
+DATAMODE
+COMPRSSD
+SUBARRAY
+SUBSTRT1
+SUBSTRT2
+SUBSIZE1
+SUBSIZE2
+FASTAXIS
+SLOWAXIS
+PATT_NUM
+SUBPXTYP
+SUBPXNUM
+SUBPXPNS
+COORDSYS
+EPH_TIME
+JWST_X
+JWST_Y
+JWST_Z
+JWST_DX
+JWST_DY
+JWST_DZ
+BARTDELT
+BSTRTIME
+BENDTIME
+BMIDTIME
+HELIDELT
+HSTRTIME
+HENDTIME
+HMIDTIME
+PHOTMJSR
+PHOTUJA2
+GS_ORDER
+GSSTRTTM
+GSENDTIM
+GDSTARID
+GS_RA
+GS_DEC
+GS_URA
+GS_UDEC
+GS_MAG
+GS_UMAG
+PCS_MODE
+GSCENTX
+GSCENTY
+JITTERMS
+VISITEND
+WFSCFLAG
+CRDS_VER
+CRDS_CTX
+R_AREA
+R_DARK
+R_FLAT
+R_GAIN
+R_IPC
+R_LINEAR
+R_MASK
+R_PHOTOM
+R_READNO
+R_SATURA
+S_IPC
+S_DQINIT
+S_SUPERB
+S_BSDRFT
+S_REFPIX
+S_DARK
+S_SATURA
+S_LINEAR
+S_JUMP
+S_RAMP
+S_WCS
+S_FLAT
+S_PERSIS
+S_TELEMI
+S_PHOTOM
+TCATFILE
+LONPOLE
+LATPOLE
+WCSNAME
+CRDER1
+CRDER2
+EQUINOX
+###############################
+#
+# JWST Header rules
+#
+###############################
+SIMPLE    SIMPLE    first
+BITPIX    BITPIX    first
+NAXIS    NAXIS    first
+EXTEND    EXTEND    first
+DATE    DATE    first
+ORIGIN    ORIGIN    first
+TIMESYS    TIMESYS    first
+FILENAME    FILENAME    first
+FILETYPE    FILETYPE    first
+SDP_VER    SDP_VER    first
+PRD_VER    PRD_VER    first
+CAL_VER    CAL_VER    first
+CAL_SVN    CAL_SVN    first
+TELESCOP    TELESCOP    first
+RADESYS    RADESYS    first
+TITLE    TITLE    first
+PI_NAME    PI_NAME    first
+CATEGORY    CATEGORY    first
+SUBCAT    SUBCAT    first
+SCICAT    SCICAT    first
+DATE-OBS    DATE-OBS    first
+TIME-OBS    TIME-OBS    first
+OBS_ID  OBS_ID    multi
+VISIT_ID  VISIT_ID  multi
+PROGRAM    PROGRAM    first
+OBSERVTN    OBSERVTN    first
+VISIT    VISIT     multi
+VISITGRP VISITGRP  multi
+SEQ_ID   SEQ_ID    multi
+ACT_ID   ACT_ID    multi
+EXPOSURE EXPOSURE  multi
+TEMPLATE    TEMPLATE    first
+OBSLABEL    OBSLABEL    first
+VISITYPE    VISITYPE    first
+VSTSTART    VSTSTART    first
+WFSVISIT    WFSVISIT    first
+NEXPOSUR    NEXPOSUR    first
+INTARGET    INTARGET    first
+TARGOOPP    TARGOOPP    first
+TARGPROP    TARGPROP    first
+TARGNAME    TARGNAME    first
+TARGTYPE    TARGTYPE    first
+TARG_RA    TARG_RA    first
+TARG_DEC    TARG_DEC    first
+TARGURA    TARGURA    first
+TARGUDEC    TARGUDEC    first
+PROP_RA    PROP_RA    first
+PROP_DEC    PROP_DEC    first
+PROPEPOC    PROPEPOC    first
+INSTRUME    INSTRUME    first
+DETECTOR    DETECTOR    first
+MODULE    MODULE    multi
+CHANNEL    CHANNEL    first
+FILTER    FILTER    first
+PUPIL    PUPIL    first
+PILIN    PILIN    first
+LAMP    LAMP    first
+PNTG_SEQ    PNTG_SEQ    first
+EXPCOUNT    EXPCOUNT    first
+EXP_TYPE    EXP_TYPE    first
+EXPSTART    EXPSTART    first
+EXPMID    EXPMID    mean
+EXPEND    EXPEND    last
+READPATT    READPATT    first
+NINTS    NINTS    first
+NGROUPS    NGROUPS    first
+NFRAMES    NFRAMES    first
+GROUPGAP    GROUPGAP    first
+NSAMPLES    NSAMPLES    first
+TSAMPLE    TSAMPLE    first
+TFRAME    TFRAME    first
+TGROUP    TGROUP    first
+EFFINTTM    EFFINTTM    first
+EFFEXPTM    EFFEXPTM    first
+CHRGTIME    CHRGTIME    first
+DURATION    DURATION    first
+NRSTSTRT    NRSTSTRT    first
+NRESETS    NRESETS    first
+ZEROFRAM    ZEROFRAM    first
+DATAPROB    DATAPROB    first
+SCA_NUM    SCA_NUM    first
+DATAMODE    DATAMODE    first
+COMPRSSD    COMPRSSD    first
+SUBARRAY    SUBARRAY    first
+SUBSTRT1    SUBSTRT1    first
+SUBSTRT2    SUBSTRT2    first
+SUBSIZE1    SUBSIZE1    first
+SUBSIZE2    SUBSIZE2    first
+FASTAXIS    FASTAXIS    first
+SLOWAXIS    SLOWAXIS    first
+PATT_NUM  PATT_NUM  multi
+SUBPXTYP  SUBPXTYP  multi
+SUBPXNUM  SUBPXNUM  multi
+SUBPXPNS  SUBPXPNS  multi
+COORDSYS    COORDSYS    first
+EPH_TIME    EPH_TIME    first
+JWST_X    JWST_X    first
+JWST_Y    JWST_Y    first
+JWST_Z    JWST_Z    first
+JWST_DX    JWST_DX    first
+JWST_DY    JWST_DY    first
+JWST_DZ    JWST_DZ    first
+APERNAME    APERNAME    first
+PA_APER    PA_APER    first
+SCA_APER    SCA_APER    first
+WCSAXES    WCSAXES    first
+CRPIX1    CRPIX1    first
+CRPIX2    CRPIX2    first
+CRVAL1    CRVAL1    first
+CRVAL2    CRVAL2    first
+CTYPE1    CTYPE1    first
+CTYPE2    CTYPE2    first
+CUNIT1    CUNIT1    first
+CUNIT2    CUNIT2    first
+CDELT1    CDELT1    first
+CDELT2    CDELT2    first
+PC1_1    PC1_1    first
+PC1_2    PC1_2    first
+PC2_1    PC2_1    first
+PC2_2    PC2_2    first
+DVA_RA    DVA_RA    first
+DVA_DEC    DVA_DEC    first
+VA_SCALE    VA_SCALE    first
+BARTDELT    BARTDELT    first
+BSTRTIME    BSTRTIME    first
+BENDTIME    BENDTIME    first
+BMIDTIME    BMIDTIME    first
+HELIDELT    HELIDELT    first
+HSTRTIME    HSTRTIME    first
+HENDTIME    HENDTIME    first
+HMIDTIME    HMIDTIME    first
+PHOTMJSR    PHOTMJSR    first
+PHOTUJA2    PHOTUJA2    first
+GS_ORDER    GS_ORDER    first
+GSSTRTTM    GSSTRTTM    first
+GSENDTIM    GSENDTIM    first
+GDSTARID    GDSTARID    first
+GS_RA    GS_RA    first
+GS_DEC    GS_DEC    first
+GS_URA    GS_URA    first
+GS_UDEC    GS_UDEC    first
+GS_MAG    GS_MAG    first
+GS_UMAG    GS_UMAG    first
+PCS_MODE    PCS_MODE    first
+GSCENTX    GSCENTX    first
+GSCENTY    GSCENTY    first
+JITTERMS    JITTERMS    first
+VISITEND    VISITEND    first
+WFSCFLAG    WFSCFLAG    first
+CRDS_VER    CRDS_VER    first
+CRDS_CTX    CRDS_CTX    first
+TCATFILE    TCATFILE    first
+LONPOLE    LONPOLE    first
+LATPOLE    LATPOLE    first
+WCSNAME    WCSNAME    first
+CRDER1    CRDER1    first
+CRDER2    CRDER2    first
+EQUINOX    EQUINOX    first

--- a/lib/fitsblender/nircam_header.rules
+++ b/lib/fitsblender/nircam_header.rules
@@ -1,0 +1,405 @@
+!VERSION = 1.1
+!INSTRUMENT = NIRCAM
+################################################################################
+#
+# Header keyword rules
+#
+# Columns definitions:
+#    Column 1: header keyword from input header or '<delete>'
+#    Column 2: [optional] name of table column for recording values from
+#              keyword specified in the first column from each input image
+#              =or= name of keyword to be updated in output image header
+#    Column 3: [optional] function to use to create output header value
+#              (output keyword name must be specified in second column)
+#
+# Any line that starts with '<delete>' indicates that that keyword
+# or set of keywords for that header section should be deleted from the
+# output header.
+#
+# Supported functions: first, last, min, max, mean, sum, stddev, multi
+#
+# Any keyword without a function will be copied to a table column with the
+# name given in the second column, or first column if only 1 column has been
+# specified.  These keywords will also be removed from the output header unless
+# another rule for the same keyword (1st column) has been specified with a
+# function named in the 3rd column.
+#
+# All keywords *not specified in this rules file* will be derived from the first
+# input image's header and used unchanged to create the final output header(s).
+# So, any keyword with a rule that adds that keyword to a table will be removed from
+# the output headers unless additional rules are provided to specify what values
+# should be kept in the header for that keyword.
+##
+# Final header output will use the same formatting and order of keywords defined
+# by the first image's headers.
+#
+# Rules for headers from all image extensions can be included in the same
+# file without regard for order, although keeping them organized by extension
+# makes the file easier to maintain and update.
+#
+# The order of the rules will determine the order of the columns in the
+# final output table. As a result, the rules for EXTNAME and EXTVER are
+# associated with ROOTNAME, rather than the SCI header, in order to make
+# rows of the table easier to identify.
+#
+# Comments appended to the end of a rule will be ignored when reading the
+# rules. All comments start with '#'.
+#
+#
+################################################################################
+#
+# Table Keyword Rules
+#
+################################################################################
+#
+# NIRCAM keywords
+#
+FILENAME
+DATE-OBS
+TIME-OBS
+EXPSTART
+EXPMID
+EXPEND
+TITLE
+PI_NAME
+CATEGORY
+SUBCAT
+SCICAT
+OBS_ID
+VISIT_ID
+PROGRAM
+OBSERVTN
+VISIT
+VISITGRP
+SEQ_ID
+ACT_ID
+APERNAME
+PA_APER
+SCA_APER
+WCSAXES
+CRPIX1
+CRPIX2
+CRVAL1
+CRVAL2
+CTYPE1
+CTYPE2
+CUNIT1
+CUNIT2
+CDELT1
+CDELT2
+PC1_1
+PC1_2
+PC2_1
+PC2_2
+DVA_RA
+DVA_DEC
+VA_SCALE
+EXPOSURE
+TEMPLATE
+OBSLABEL
+DATE
+ORIGIN
+TIMESYS
+FILETYPE
+SDP_VER
+PRD_VER
+CAL_VER
+CAL_SVN
+TELESCOP
+RADESYS
+TITLE
+PI_NAME
+CATEGORY
+SUBCAT
+SCICAT
+DATE-OBS
+TIME-OBS
+VISITYPE
+VSTSTART
+WFSVISIT
+NEXPOSUR
+INTARGET
+TARGOOPP
+TARGPROP
+TARGNAME
+TARGTYPE
+TARG_RA
+TARG_DEC
+TARGURA
+TARGUDEC
+PROP_RA
+PROP_DEC
+PROPEPOC
+INSTRUME
+DETECTOR
+MODULE
+CHANNEL
+FILTER
+PUPIL
+PILIN
+LAMP
+PNTG_SEQ
+EXPCOUNT
+EXP_TYPE
+READPATT
+NINTS
+NGROUPS
+NFRAMES
+GROUPGAP
+NSAMPLES
+TSAMPLE
+TFRAME
+TGROUP
+EFFINTTM
+EFFEXPTM
+CHRGTIME
+DURATION
+NRSTSTRT
+NRESETS
+ZEROFRAM
+DATAPROB
+SCA_NUM
+DATAMODE
+COMPRSSD
+SUBARRAY
+SUBSTRT1
+SUBSTRT2
+SUBSIZE1
+SUBSIZE2
+FASTAXIS
+SLOWAXIS
+PATT_NUM
+SUBPXTYP
+SUBPXNUM
+SUBPXPNS
+COORDSYS
+EPH_TIME
+JWST_X
+JWST_Y
+JWST_Z
+JWST_DX
+JWST_DY
+JWST_DZ
+BARTDELT
+BSTRTIME
+BENDTIME
+BMIDTIME
+HELIDELT
+HSTRTIME
+HENDTIME
+HMIDTIME
+PHOTMJSR
+PHOTUJA2
+GS_ORDER
+GSSTRTTM
+GSENDTIM
+GDSTARID
+GS_RA
+GS_DEC
+GS_URA
+GS_UDEC
+GS_MAG
+GS_UMAG
+PCS_MODE
+GSCENTX
+GSCENTY
+JITTERMS
+VISITEND
+WFSCFLAG
+CRDS_VER
+CRDS_CTX
+R_AREA
+R_DARK
+R_FLAT
+R_GAIN
+R_IPC
+R_LINEAR
+R_MASK
+R_PHOTOM
+R_READNO
+R_SATURA
+S_IPC
+S_DQINIT
+S_SUPERB
+S_BSDRFT
+S_REFPIX
+S_DARK
+S_SATURA
+S_LINEAR
+S_JUMP
+S_RAMP
+S_WCS
+S_FLAT
+S_PERSIS
+S_TELEMI
+S_PHOTOM
+TCATFILE
+LONPOLE
+LATPOLE
+WCSNAME
+CRDER1
+CRDER2
+EQUINOX
+###############################
+#
+# NIRCAM Header rules
+#
+###############################
+SIMPLE    SIMPLE    first
+BITPIX    BITPIX    first
+NAXIS    NAXIS    first
+EXTEND    EXTEND    first
+DATE    DATE    first
+ORIGIN    ORIGIN    first
+TIMESYS    TIMESYS    first
+FILENAME    FILENAME    first
+FILETYPE    FILETYPE    first
+SDP_VER    SDP_VER    first
+PRD_VER    PRD_VER    first
+CAL_VER    CAL_VER    first
+CAL_SVN    CAL_SVN    first
+TELESCOP    TELESCOP    first
+RADESYS    RADESYS    first
+TITLE    TITLE    first
+PI_NAME    PI_NAME    first
+CATEGORY    CATEGORY    first
+SUBCAT    SUBCAT    first
+SCICAT    SCICAT    first
+DATE-OBS    DATE-OBS    first
+TIME-OBS    TIME-OBS    first
+OBS_ID  OBS_ID    multi
+VISIT_ID  VISIT_ID  multi
+PROGRAM    PROGRAM    first
+OBSERVTN    OBSERVTN    first
+VISIT    VISIT     multi
+VISITGRP VISITGRP  multi
+SEQ_ID   SEQ_ID    multi
+ACT_ID   ACT_ID    multi
+EXPOSURE EXPOSURE  multi
+TEMPLATE    TEMPLATE    first
+OBSLABEL    OBSLABEL    first
+VISITYPE    VISITYPE    first
+VSTSTART    VSTSTART    first
+WFSVISIT    WFSVISIT    first
+NEXPOSUR    NEXPOSUR    first
+INTARGET    INTARGET    first
+TARGOOPP    TARGOOPP    first
+TARGPROP    TARGPROP    first
+TARGNAME    TARGNAME    first
+TARGTYPE    TARGTYPE    first
+TARG_RA    TARG_RA    first
+TARG_DEC    TARG_DEC    first
+TARGURA    TARGURA    first
+TARGUDEC    TARGUDEC    first
+PROP_RA    PROP_RA    first
+PROP_DEC    PROP_DEC    first
+PROPEPOC    PROPEPOC    first
+INSTRUME    INSTRUME    first
+DETECTOR    DETECTOR    first
+MODULE    MODULE    multi
+CHANNEL    CHANNEL    first
+FILTER    FILTER    first
+PUPIL    PUPIL    first
+PILIN    PILIN    first
+LAMP    LAMP    first
+PNTG_SEQ    PNTG_SEQ    first
+EXPCOUNT    EXPCOUNT    first
+EXP_TYPE    EXP_TYPE    first
+EXPSTART    EXPSTART    first
+EXPMID    EXPMID    mean
+EXPEND    EXPEND    last
+READPATT    READPATT    first
+NINTS    NINTS    first
+NGROUPS    NGROUPS    first
+NFRAMES    NFRAMES    first
+GROUPGAP    GROUPGAP    first
+NSAMPLES    NSAMPLES    first
+TSAMPLE    TSAMPLE    first
+TFRAME    TFRAME    first
+TGROUP    TGROUP    first
+EFFINTTM    EFFINTTM    first
+EFFEXPTM    EFFEXPTM    first
+CHRGTIME    CHRGTIME    first
+DURATION    DURATION    first
+NRSTSTRT    NRSTSTRT    first
+NRESETS    NRESETS    first
+ZEROFRAM    ZEROFRAM    first
+DATAPROB    DATAPROB    first
+SCA_NUM    SCA_NUM    first
+DATAMODE    DATAMODE    first
+COMPRSSD    COMPRSSD    first
+SUBARRAY    SUBARRAY    first
+SUBSTRT1    SUBSTRT1    first
+SUBSTRT2    SUBSTRT2    first
+SUBSIZE1    SUBSIZE1    first
+SUBSIZE2    SUBSIZE2    first
+FASTAXIS    FASTAXIS    first
+SLOWAXIS    SLOWAXIS    first
+PATT_NUM  PATT_NUM  multi
+SUBPXTYP  SUBPXTYP  multi
+SUBPXNUM  SUBPXNUM  multi
+SUBPXPNS  SUBPXPNS  multi
+COORDSYS    COORDSYS    first
+EPH_TIME    EPH_TIME    first
+JWST_X    JWST_X    first
+JWST_Y    JWST_Y    first
+JWST_Z    JWST_Z    first
+JWST_DX    JWST_DX    first
+JWST_DY    JWST_DY    first
+JWST_DZ    JWST_DZ    first
+APERNAME    APERNAME    first
+PA_APER    PA_APER    first
+SCA_APER    SCA_APER    first
+WCSAXES    WCSAXES    first
+CRPIX1    CRPIX1    first
+CRPIX2    CRPIX2    first
+CRVAL1    CRVAL1    first
+CRVAL2    CRVAL2    first
+CTYPE1    CTYPE1    first
+CTYPE2    CTYPE2    first
+CUNIT1    CUNIT1    first
+CUNIT2    CUNIT2    first
+CDELT1    CDELT1    first
+CDELT2    CDELT2    first
+PC1_1    PC1_1    first
+PC1_2    PC1_2    first
+PC2_1    PC2_1    first
+PC2_2    PC2_2    first
+DVA_RA    DVA_RA    first
+DVA_DEC    DVA_DEC    first
+VA_SCALE    VA_SCALE    first
+BARTDELT    BARTDELT    first
+BSTRTIME    BSTRTIME    first
+BENDTIME    BENDTIME    first
+BMIDTIME    BMIDTIME    first
+HELIDELT    HELIDELT    first
+HSTRTIME    HSTRTIME    first
+HENDTIME    HENDTIME    first
+HMIDTIME    HMIDTIME    first
+PHOTMJSR    PHOTMJSR    first
+PHOTUJA2    PHOTUJA2    first
+GS_ORDER    GS_ORDER    first
+GSSTRTTM    GSSTRTTM    first
+GSENDTIM    GSENDTIM    first
+GDSTARID    GDSTARID    first
+GS_RA    GS_RA    first
+GS_DEC    GS_DEC    first
+GS_URA    GS_URA    first
+GS_UDEC    GS_UDEC    first
+GS_MAG    GS_MAG    first
+GS_UMAG    GS_UMAG    first
+PCS_MODE    PCS_MODE    first
+GSCENTX    GSCENTX    first
+GSCENTY    GSCENTY    first
+JITTERMS    JITTERMS    first
+VISITEND    VISITEND    first
+WFSCFLAG    WFSCFLAG    first
+CRDS_VER    CRDS_VER    first
+CRDS_CTX    CRDS_CTX    first
+TCATFILE    TCATFILE    first
+LONPOLE    LONPOLE    first
+LATPOLE    LATPOLE    first
+WCSNAME    WCSNAME    first
+CRDER1    CRDER1    first
+CRDER2    CRDER2    first
+EQUINOX    EQUINOX    first

--- a/lib/fitsblender/nirspec_header.rules
+++ b/lib/fitsblender/nirspec_header.rules
@@ -1,0 +1,437 @@
+!VERSION = 1.1
+!INSTRUMENT = NIRSPEC
+################################################################################
+#
+# Header keyword rules
+#
+# Columns definitions:
+#    Column 1: header keyword from input header or '<delete>'
+#    Column 2: [optional] name of table column for recording values from
+#              keyword specified in the first column from each input image
+#              =or= name of keyword to be updated in output image header
+#    Column 3: [optional] function to use to create output header value
+#              (output keyword name must be specified in second column)
+#
+# Any line that starts with '<delete>' indicates that that keyword
+# or set of keywords for that header section should be deleted from the
+# output header.
+#
+# Supported functions: first, last, min, max, mean, sum, stddev, multi
+#
+# Any keyword without a function will be copied to a table column with the
+# name given in the second column, or first column if only 1 column has been
+# specified.  These keywords will also be removed from the output header unless
+# another rule for the same keyword (1st column) has been specified with a
+# function named in the 3rd column.
+#
+# All keywords *not specified in this rules file* will be derived from the first
+# input image's header and used unchanged to create the final output header(s).
+# So, any keyword with a rule that adds that keyword to a table will be removed from
+# the output headers unless additional rules are provided to specify what values
+# should be kept in the header for that keyword.
+##
+# Final header output will use the same formatting and order of keywords defined
+# by the first image's headers.
+#
+# Rules for headers from all image extensions can be included in the same
+# file without regard for order, although keeping them organized by extension
+# makes the file easier to maintain and update.
+#
+# The order of the rules will determine the order of the columns in the
+# final output table. As a result, the rules for EXTNAME and EXTVER are
+# associated with ROOTNAME, rather than the SCI header, in order to make
+# rows of the table easier to identify.
+#
+# Comments appended to the end of a rule will be ignored when reading the
+# rules. All comments start with '#'.
+#
+#
+################################################################################
+#
+# Table Keyword Rules
+#
+################################################################################
+FILENAME
+EXTNAME
+EXTVER
+WCSAXES
+CRPIX1
+CRPIX2
+CRVAL1
+CRVAL2
+CRVAL3
+BITPIX
+NAXIS
+EXTEND
+DATE
+ORIGIN
+FILETYPE
+CAL_VER
+CAL_SVN
+TELESCOP
+RADESYS
+ASNPOOL
+ASNTABLE
+TITLE
+PI_NAME
+CATEGORY
+SUBCAT
+SCICAT
+CONT_ID
+DATE-OBS
+TIME-OBS
+OBS_ID
+VISIT_ID
+PROGRAM
+OBSERVTN
+VISIT
+VISITGRP
+SEQ_ID
+ACT_ID
+EXPOSURE
+TEMPLATE
+OBSLABEL
+VISITYPE
+VSTSTART
+WFSVISIT
+NEXPOSUR
+INTARGET
+TARGOOPP
+TARGPROP
+TARGNAME
+TARGTYPE
+TARG_RA
+TARG_DEC
+TARGURA
+PROP_RA
+PROP_DEC
+INSTRUME
+DETECTOR
+FILTER
+GRATING
+FXD_SLIT
+FOCUSPOS
+MSASTATE
+MSACONFL
+LAMP
+GWA_XTIL
+GWA_YTIL
+PNTG_SEQ
+EXPCOUNT
+EXP_TYPE
+EXPSTART
+EXPMID
+EXPEND
+READPATT
+NINTS
+NGROUPS
+NFRAMES
+GROUPGAP
+NSAMPLES
+TSAMPLE
+TFRAME
+TGROUP
+EFFINTTM
+EFFEXPTM
+CHRGTIME
+DURATION
+NRSTSTRT
+ZEROFRAM
+DATAPROB
+SUBARRAY
+SUBSTRT1
+SUBSTRT2
+SUBSIZE1
+SUBSIZE2
+FASTAXIS
+SLOWAXIS
+COORDSYS
+EPH_TIME
+JWST_X
+JWST_Y
+JWST_Z
+JWST_DX
+JWST_DY
+JWST_DZ
+APERNAME
+PA_APER
+CTYPE1
+CTYPE2
+CTYPE3
+CUNIT1
+CUNIT2
+CUNIT3
+CDELT1
+CDELT2
+CDELT3
+PC1_1
+PC1_2
+PC2_1
+PC2_2
+PC3_1
+PC3_2
+WAVSTART
+WAVEND
+SPORDER
+RA_REF
+DEC_REF
+V2_REF
+V3_REF
+ROLL_REF
+DVA_RA
+DVA_DEC
+VA_SCALE
+BARTDELT
+BSTRTIME
+BENDTIME
+BMIDTIME
+HELIDELT
+HSTRTIME
+HENDTIME
+HMIDTIME
+PHOTMJSR
+PHOTUJA2
+GSSTRTTM
+GSENDTIM
+GDSTARID
+CRDS_VER
+CRDS_CTX
+R_AREA
+R_DARK
+R_GAIN
+R_IFUFOR
+R_IFUPOS
+R_IFUSLI
+R_LINEAR
+R_MASK
+R_PHOTOM
+R_READNO
+R_SATURA
+R_SUPERB
+R_DISTOR
+R_FILOFF
+R_SPDIST
+R_REGION
+R_WAVRAN
+R_V2V3
+R_CAMERA
+R_COLLIM
+R_DISPER
+R_FORE
+R_FPA
+R_MSA
+R_OTE
+S_DQINIT
+S_SUPERB
+S_REFPIX
+S_DARK
+S_SATURA
+S_LINEAR
+S_JUMP
+S_RAMP
+S_WCS
+S_PHOTOM
+S_EXTR2D
+MSACONFG
+NEXTEND
+DPSW_VER
+EXTARGET
+TARRUDEC
+NRESET
+NXLIGHT
+GWAXTILT
+GWAYTILT
+GSURA
+GSUDEC
+GSUMAG
+XTENSION
+BITPIX
+NAXIS
+NAXIS1
+NAXIS2
+PCOUNT
+GCOUNT
+SLTNAME
+SLTSTRT1
+SLTSIZE1
+SLTSTRT2
+SLTSIZE2
+BUNIT
+O_BZERO
+################################################################################
+#
+# Header Keyword Rules
+#
+################################################################################
+SIMPLE SIMPLE  first
+BITPIX BITPIX  first
+NAXIS NAXIS  first
+EXTEND EXTEND  first
+DATE DATE  first
+ORIGIN ORIGIN  first
+FILENAME FILENAME  first
+FILETYPE FILETYPE  first
+CAL_VER CAL_VER  first
+CAL_SVN CAL_SVN  first
+TELESCOP TELESCOP  first
+RADESYS RADESYS  first
+ASNPOOL ASNPOOL  first
+ASNTABLE ASNTABLE  first
+TITLE TITLE  first
+PI_NAME PI_NAME  first
+CATEGORY CATEGORY  first
+SUBCAT SUBCAT  first
+SCICAT SCICAT  first
+CONT_ID CONT_ID  first
+DATE-OBS DATE-OBS  first
+TIME-OBS TIME-OBS  first
+OBS_ID OBS_ID  first
+VISIT_ID VISIT_ID  first
+PROGRAM PROGRAM  first
+OBSERVTN OBSERVTN  first
+VISIT VISIT  first
+VISITGRP VISITGRP  first
+SEQ_ID SEQ_ID  first
+ACT_ID ACT_ID  first
+EXPOSURE EXPOSURE  first
+TEMPLATE TEMPLATE  first
+OBSLABEL OBSLABEL  first
+VISITYPE VISITYPE  first
+VSTSTART VSTSTART  first
+WFSVISIT WFSVISIT  first
+NEXPOSUR NEXPOSUR  first
+INTARGET INTARGET  first
+TARGOOPP TARGOOPP  first
+TARGPROP TARGPROP  first
+TARGNAME TARGNAME  first
+TARGTYPE TARGTYPE  first
+TARG_RA TARG_RA  first
+TARG_DEC TARG_DEC  first
+TARGURA TARGURA  first
+PROP_RA PROP_RA  first
+PROP_DEC PROP_DEC  first
+INSTRUME INSTRUME  first
+DETECTOR DETECTOR  first
+FILTER FILTER  first
+GRATING GRATING  first
+FXD_SLIT FXD_SLIT  first
+FOCUSPOS FOCUSPOS  first
+MSASTATE MSASTATE  first
+MSACONFL MSACONFL  first
+LAMP LAMP  first
+GWA_XTIL GWA_XTIL  first
+GWA_YTIL GWA_YTIL  first
+PNTG_SEQ PNTG_SEQ  first
+EXPCOUNT EXPCOUNT  first
+EXP_TYPE EXP_TYPE  first
+EXPSTART EXPSTART  first
+EXPMID EXPMID  first
+EXPEND EXPEND  first
+READPATT READPATT  first
+NINTS NINTS  first
+NGROUPS NGROUPS  first
+NFRAMES NFRAMES  first
+GROUPGAP GROUPGAP  first
+NSAMPLES NSAMPLES  first
+TSAMPLE TSAMPLE  first
+TFRAME TFRAME  first
+TGROUP TGROUP  first
+EFFINTTM EFFINTTM  first
+EFFEXPTM EFFEXPTM  first
+CHRGTIME CHRGTIME  first
+DURATION DURATION  first
+NRSTSTRT NRSTSTRT  first
+ZEROFRAM ZEROFRAM  first
+DATAPROB DATAPROB  first
+SUBARRAY SUBARRAY  first
+SUBSTRT1 SUBSTRT1  first
+SUBSTRT2 SUBSTRT2  first
+SUBSIZE1 SUBSIZE1  first
+SUBSIZE2 SUBSIZE2  first
+FASTAXIS FASTAXIS  first
+SLOWAXIS SLOWAXIS  first
+COORDSYS COORDSYS  first
+EPH_TIME EPH_TIME  first
+JWST_X JWST_X  first
+JWST_Y JWST_Y  first
+JWST_Z JWST_Z  first
+JWST_DX JWST_DX  first
+JWST_DY JWST_DY  first
+JWST_DZ JWST_DZ  first
+APERNAME APERNAME  first
+PA_APER PA_APER  first
+WCSAXES WCSAXES  first
+CRPIX1 CRPIX1  first
+CRPIX2 CRPIX2  first
+CRVAL1 CRVAL1  first
+CRVAL2 CRVAL2  first
+CRVAL3 CRVAL3  first
+CTYPE1 CTYPE1  first
+CTYPE2 CTYPE2  first
+CTYPE3 CTYPE3  first
+CUNIT1 CUNIT1  first
+CUNIT2 CUNIT2  first
+CUNIT3 CUNIT3  first
+CDELT1 CDELT1  first
+CDELT2 CDELT2  first
+CDELT3 CDELT3  first
+PC1_1 PC1_1  first
+PC1_2 PC1_2  first
+PC2_1 PC2_1  first
+PC2_2 PC2_2  first
+PC3_1 PC3_1  first
+PC3_2 PC3_2  first
+WAVSTART WAVSTART  first
+WAVEND WAVEND  first
+SPORDER SPORDER  first
+RA_REF RA_REF  first
+DEC_REF DEC_REF  first
+V2_REF V2_REF  first
+V3_REF V3_REF  first
+ROLL_REF ROLL_REF  first
+DVA_RA DVA_RA  first
+DVA_DEC DVA_DEC  first
+VA_SCALE VA_SCALE  first
+BARTDELT BARTDELT  first
+BSTRTIME BSTRTIME  first
+BENDTIME BENDTIME  first
+BMIDTIME BMIDTIME  first
+HELIDELT HELIDELT  first
+HSTRTIME HSTRTIME  first
+HENDTIME HENDTIME  first
+HMIDTIME HMIDTIME  first
+PHOTMJSR PHOTMJSR  first
+PHOTUJA2 PHOTUJA2  first
+GSSTRTTM GSSTRTTM  first
+GSENDTIM GSENDTIM  first
+GDSTARID GDSTARID  first
+CRDS_VER CRDS_VER  first
+CRDS_CTX CRDS_CTX  first
+MSACONFG MSACONFG  first
+NEXTEND NEXTEND  first
+DPSW_VER DPSW_VER  first
+EXTARGET EXTARGET  first
+TARRUDEC TARRUDEC  first
+NRESET NRESET  first
+NXLIGHT NXLIGHT  first
+GWAXTILT GWAXTILT  first
+GWAYTILT GWAYTILT  first
+GSURA GSURA  first
+GSUDEC GSUDEC  first
+GSUMAG GSUMAG  first
+XTENSION XTENSION  first
+BITPIX BITPIX  first
+NAXIS NAXIS  first
+NAXIS1 NAXIS1  first
+NAXIS2 NAXIS2  first
+PCOUNT PCOUNT  first
+GCOUNT GCOUNT  first
+EXTNAME EXTNAME  first
+EXTVER EXTVER  first
+SLTNAME SLTNAME  first
+SLTSTRT1 SLTSTRT1  first
+SLTSIZE1 SLTSIZE1  first
+SLTSTRT2 SLTSTRT2  first
+SLTSIZE2 SLTSIZE2  first
+BUNIT BUNIT  first
+O_BZERO O_BZERO  first

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,10 +21,10 @@ setup_hooks =
 name = fitsblender
 author = Michael Droettboom
 requires-python = >=2.7
-vdate = 07-Oct-2016
+vdate = 17-Oct-2016
 home-page = http://www.stsci.edu/resources/software_hardware/pyraf/stsci_python
 summary = Aggregate values in FITS headers
-version = 0.2.7
+version = 0.3.0
 classifier =
 	Intended Audience :: Science/Research
 	License :: OSI Approved :: BSD License


### PR DESCRIPTION
This set of changes adds telescope level default rules files for use with fitsblender, allowing it to run (within the limits of the default rules file) on any data from that particular telescope.  A default file for both HST (based on ACS) and JWST (based on NIRCAM) have been included.  Instrument-specific rules still need to be developed for JWST data, but this will allow for initial use of this code for testing.  
