### PR TITLE
Fix string type check for python 3

### DIFF
--- a/lib/fitsblender/blendheaders.py
+++ b/lib/fitsblender/blendheaders.py
@@ -318,6 +318,12 @@ def get_blended_headers(inputs, verbose=False,extlist=['SCI','ERR','DQ']):
     if not isinstance(inputs, list):
         inputs = [inputs]
 
+    # for python2/3 compatibility
+    try:
+        basestring
+    except NameError:
+        basestring = str
+
     phdrdict = collections.OrderedDict() #{}
     # Turn input filenames into a set of header objects
     if isinstance(inputs[0], basestring):


### PR DESCRIPTION
Running astrodrizzle under python 3 crashes because `basestring` is undefined here.

An alternative solution is to simply replace `basestring` with `str` if we don't allow byte-string inputs.