### PR TITLE
Remove printing TEAL import info when run outside of Pyraf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ dist
 *.egg-info
 .eggs
 version.py
-
+*.pyc

--- a/lib/fitsblender/__init__.py
+++ b/lib/fitsblender/__init__.py
@@ -29,6 +29,7 @@
 # DAMAGE.
 from __future__ import absolute_import
 import os
+import sys
 
 from . import blender
 from .blender import fitsblender
@@ -39,7 +40,9 @@ from . import blendheaders
 # upon importing this package.
 from stsci.tools import teal
 
-# teal.print_tasknames(__name__, os.path.dirname(__file__))
+# Only print if running from pyraf
+if sys._getframe(1).f_code.co_name == '_irafImport':
+    teal.print_tasknames(__name__, os.path.dirname(__file__))
 
 from .version import *
 

--- a/lib/fitsblender/blendheaders.py
+++ b/lib/fitsblender/blendheaders.py
@@ -377,7 +377,9 @@ def get_blended_headers(inputs, verbose=False, extlist=['SCI','ERR','DQ'], rules
         if inst not in icache:
             # initialize the appropriate class for this data's instrument
             inst_class = KeywordRules(inst, telescope=tel, rules_file=rules_file)
-            print("Found RULEFILE for {}/{} of: {}".format(tel,inst, inst_class.rules_file))
+            if verbose:
+                print("Found RULEFILE for {}/{} of: {}".format(tel, inst,
+                    inst_class.rules_file))
             # Interpret rules for this class based on image that
             # initialized this instrument's rules
             inst_class.interpret_rules(hlist)


### PR DESCRIPTION
TEAL-related info is printed to stdout whenever fitsblender is
imported, and this is not wanted in the JWST pipeline.  This fix
checks to see that Pyraf is importing fitsblender, and if so, only
then prints the TEAL-related info.