### PR TITLE
Change six library import

### DIFF
--- a/lib/fitsblender/blendheaders.py
+++ b/lib/fitsblender/blendheaders.py
@@ -8,7 +8,7 @@ import collections
 
 import numpy as np
 from astropy.io import fits
-from astropy.extern import six
+import six
 
 from stsci.tools import fileutil, textutil, parseinput
 


### PR DESCRIPTION
Astropy is dropping support for Python 2. To insulate ourselves from this chane, we are no longer using the astropy six library.