### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include * *
+prune .git
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,10 +21,10 @@ setup_hooks =
 name = fitsblender
 author = Michael Droettboom
 requires-python = >=2.7
-vdate = 05-Jul-2017
+vdate = 15-Jun-2018
 home-page = http://www.stsci.edu/resources/software_hardware/pyraf/stsci_python
 summary = Aggregate values in FITS headers
-version = 0.3.2
+version = 0.3.3
 classifier =
 	Intended Audience :: Science/Research
 	License :: OSI Approved :: BSD License


### PR DESCRIPTION
* Bump version

Fixes:
```
[linux/install-py=3.6,np=latest,ap=latest] >       astrodrizzle.AstroDrizzle(inputs, configobj=adriz_parobj)
[linux/install-py=3.6,np=latest,ap=latest] 
[linux/install-py=3.6,np=latest,ap=latest] ../../tests/stis/test_stis.py:99: 
[linux/install-py=3.6,np=latest,ap=latest] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[linux/install-py=3.6,np=latest,ap=latest] ../../drizzlepac/astrodrizzle.py:122: in AstroDrizzle
[linux/install-py=3.6,np=latest,ap=latest]     run(configObj, wcsmap=wcsmap)
[linux/install-py=3.6,np=latest,ap=latest] ../../drizzlepac/util.py:229: in wrapper
[linux/install-py=3.6,np=latest,ap=latest]     raise errorobj
[linux/install-py=3.6,np=latest,ap=latest] ../../drizzlepac/util.py:218: in wrapper
[linux/install-py=3.6,np=latest,ap=latest]     func(*args, **kwargs)
[linux/install-py=3.6,np=latest,ap=latest] ../../drizzlepac/astrodrizzle.py:230: in run
[linux/install-py=3.6,np=latest,ap=latest]     procSteps=procSteps)
[linux/install-py=3.6,np=latest,ap=latest] ../../drizzlepac/adrizzle.py:390: in drizFinal
[linux/install-py=3.6,np=latest,ap=latest]     build=build, wcsmap=wcsmap)
[linux/install-py=3.6,np=latest,ap=latest] ../../drizzlepac/adrizzle.py:674: in run_driz
[linux/install-py=3.6,np=latest,ap=latest]     _chipIdx,_outsci,_outwht,_outctx,_hdrlist,wcsmap)
[linux/install-py=3.6,np=latest,ap=latest] ../../drizzlepac/adrizzle.py:732: in run_driz_img
[linux/install-py=3.6,np=latest,ap=latest]     chipIdxCopy,_outsci,_outwht,_outctx,_hdrlist,wcsmap)
[linux/install-py=3.6,np=latest,ap=latest] ../../drizzlepac/adrizzle.py:984: in run_driz_chip
[linux/install-py=3.6,np=latest,ap=latest]     versions=_versions,virtual=img.inmemory)
[linux/install-py=3.6,np=latest,ap=latest] ../../drizzlepac/outputimage.py:246: in writeFITS
[linux/install-py=3.6,np=latest,ap=latest]     newhdrs, newtab = getTemplates(template,blend=blend)
[linux/install-py=3.6,np=latest,ap=latest] ../../drizzlepac/outputimage.py:692: in getTemplates
[linux/install-py=3.6,np=latest,ap=latest]     newhdrs, newtab = blendheaders.get_blended_headers(inputs=fnames)
[linux/install-py=3.6,np=latest,ap=latest] /opt/conda/envs/3.6/lib/python3.6/site-packages/fitsblender/blendheaders.py:379: in get_blended_headers
[linux/install-py=3.6,np=latest,ap=latest]     inst_class = KeywordRules(inst, telescope=tel, rules_file=rules_file)
[linux/install-py=3.6,np=latest,ap=latest] /opt/conda/envs/3.6/lib/python3.6/site-packages/fitsblender/blendheaders.py:443: in __init__
[linux/install-py=3.6,np=latest,ap=latest]     self.get_filename() # define rules file
[linux/install-py=3.6,np=latest,ap=latest] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[linux/install-py=3.6,np=latest,ap=latest] 
[linux/install-py=3.6,np=latest,ap=latest] self = <fitsblender.blendheaders.KeywordRules object at 0x7f985c9140f0>
[linux/install-py=3.6,np=latest,ap=latest] 
[linux/install-py=3.6,np=latest,ap=latest]     def get_filename(self):
[linux/install-py=3.6,np=latest,ap=latest]         """ Return name of rules file to be used
[linux/install-py=3.6,np=latest,ap=latest]             It will use a local copy if present, and use the installed version
[linux/install-py=3.6,np=latest,ap=latest]             by default. Any local copy will take precendence over the default rules.
[linux/install-py=3.6,np=latest,ap=latest]     
[linux/install-py=3.6,np=latest,ap=latest]             This function will return the alphabetically first file that applies
[linux/install-py=3.6,np=latest,ap=latest]             to the instrument and meets the version requirements
[linux/install-py=3.6,np=latest,ap=latest]             """
[linux/install-py=3.6,np=latest,ap=latest]         rules_file = None
[linux/install-py=3.6,np=latest,ap=latest]         # get all potential local rules
[linux/install-py=3.6,np=latest,ap=latest]         rfiles = glob.glob('*.rules')
[linux/install-py=3.6,np=latest,ap=latest]         rfiles.sort()
[linux/install-py=3.6,np=latest,ap=latest]     
[linux/install-py=3.6,np=latest,ap=latest]         # Sort through list and find only applicable rules files
[linux/install-py=3.6,np=latest,ap=latest]         # This would include picking up any rules files using the default
[linux/install-py=3.6,np=latest,ap=latest]         # naming convention; namely, <instrument>_header.rules
[linux/install-py=3.6,np=latest,ap=latest]         for r in rfiles:
[linux/install-py=3.6,np=latest,ap=latest]             v,i = self.get_rules_header(r)
[linux/install-py=3.6,np=latest,ap=latest]             if v is None or i is None:
[linux/install-py=3.6,np=latest,ap=latest]                 continue
[linux/install-py=3.6,np=latest,ap=latest]             if v <= __rules_version__ and i == self.instrument.lower():
[linux/install-py=3.6,np=latest,ap=latest]                 rules_file = r
[linux/install-py=3.6,np=latest,ap=latest]                 break
[linux/install-py=3.6,np=latest,ap=latest]     
[linux/install-py=3.6,np=latest,ap=latest]         if rules_file is None:
[linux/install-py=3.6,np=latest,ap=latest]             # define default rules name installed with the software
[linux/install-py=3.6,np=latest,ap=latest]             rules_name = self.instrument.lower()+self.rules_name_suffix
[linux/install-py=3.6,np=latest,ap=latest]             rules_file = os.path.join(os.path.dirname(__file__),rules_name)
[linux/install-py=3.6,np=latest,ap=latest]             if not os.path.exists(rules_file):
[linux/install-py=3.6,np=latest,ap=latest]                 rules_name = self.telescope+self.rules_name_suffix
[linux/install-py=3.6,np=latest,ap=latest]                 rules_file = os.path.join(os.path.dirname(__file__),rules_name)
[linux/install-py=3.6,np=latest,ap=latest]                 if not os.path.exists(rules_file):
[linux/install-py=3.6,np=latest,ap=latest]                     rules_file = None
[linux/install-py=3.6,np=latest,ap=latest]     
[linux/install-py=3.6,np=latest,ap=latest]         if rules_file is None:
[linux/install-py=3.6,np=latest,ap=latest]             errmsg = 'ERROR:\n'+'    No valid rules file found for:\n'
[linux/install-py=3.6,np=latest,ap=latest]             errmsg += '    INSTRUMENT = %s\n'%(self.instrument)
[linux/install-py=3.6,np=latest,ap=latest]             errmsg += '    RULES Version <= %s\n'%(__rules_version__)
[linux/install-py=3.6,np=latest,ap=latest]             print(textutil.textbox(errmsg))
[linux/install-py=3.6,np=latest,ap=latest] >           raise ValueError
[linux/install-py=3.6,np=latest,ap=latest] E           ValueError
[linux/install-py=3.6,np=latest,ap=latest] 
[linux/install-py=3.6,np=latest,ap=latest] /opt/conda/envs/3.6/lib/python3.6/site-packages/fitsblender/blendheaders.py:494: ValueError
```