### PR TITLE
Insure rule for WCSNAME added to all instruments rules

### DIFF
--- a/lib/fitsblender/acs_header.rules
+++ b/lib/fitsblender/acs_header.rules
@@ -340,6 +340,7 @@ VAFACTOR
 WCSAXES
 WCSCDATE
 WFCMPRSD
+WCSNAME
 WRTERR
 XTENSION
 #
@@ -398,6 +399,7 @@ SNRMEAN   SNRMEAN   mean
 SNRMIN    SNRMIN    min
 TARGNAME  TARGNAME  first
 TELESCOP  TELESCOP  first
+WCSNAME   WCSNAME   first
 ### rules below were added 05Jun2012,in response to Dorothy Fraquelli guidance re: DADS
 ATODCORR  ATODCORR  multi
 ATODGNA   ATODGNA   first

--- a/lib/fitsblender/hst_header.rules
+++ b/lib/fitsblender/hst_header.rules
@@ -340,6 +340,7 @@ VAFACTOR
 WCSAXES
 WCSCDATE
 WFCMPRSD
+WCSNAME
 WRTERR
 XTENSION
 #
@@ -398,6 +399,7 @@ SNRMEAN   SNRMEAN   mean
 SNRMIN    SNRMIN    min
 TARGNAME  TARGNAME  first
 TELESCOP  TELESCOP  first
+WCSNAME   WCSNAME   first
 ### rules below were added 05Jun2012,in response to Dorothy Fraquelli guidance re: DADS
 ATODCORR  ATODCORR  multi
 ATODGNA   ATODGNA   first

--- a/lib/fitsblender/nicmos_header.rules
+++ b/lib/fitsblender/nicmos_header.rules
@@ -323,6 +323,7 @@ UNITCORR
 VAFACTOR
 WCSAXES
 WCSCDATE
+WCSNAME
 ZOFFCORR
 ZSIGCORR
 ################################################################################

--- a/lib/fitsblender/stis_header.rules
+++ b/lib/fitsblender/stis_header.rules
@@ -323,6 +323,7 @@ UNITCORR
 VAFACTOR
 WCSAXES
 WCSCDATE
+WCSNAME
 ZOFFCORR
 ZSIGCORR
 ################################################################################

--- a/lib/fitsblender/wfc3_header.rules
+++ b/lib/fitsblender/wfc3_header.rules
@@ -323,6 +323,7 @@ UNITCORR
 VAFACTOR
 WCSAXES
 WCSCDATE
+WCSNAME
 ZOFFCORR
 ZSIGCORR
 ################################################################################


### PR DESCRIPTION
The value of WCSNAME for each input exposure needs to be added to the HDRTAB extension for all drizzle products to provide a history of what WCS solutions were used to align the product.  In addition, the keyword WCSNAME needs to be included in the science headers for all products as well.  Changes in the Drizzlepac code itself will then need to be implemented to populate this keyword properly.  