### PR TITLE
Updating version to 0.3.5 for new release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ requires-python = >=2.7
 vdate = 15-Jun-2018
 home-page = http://www.stsci.edu/resources/software_hardware/pyraf/stsci_python
 summary = Aggregate values in FITS headers
-version = 0.3.3
+version = 0.3.5
 classifier =
 	Intended Audience :: Science/Research
 	License :: OSI Approved :: BSD License


### PR DESCRIPTION
Update version in package to allow users to know when they actually have the new version of fitsblender with the latest rules (as delivered to the HST pipeline).  Once merged, a new tag will need to be created for this package which matches this version so that the release package can be updated correctly, given that the v0.3.4 tag did not get picked up and the internal version had not been updated to match that specific tag.  

This will also allow drizzlepac to pin to this new version and be assured of getting the right code.  