### PR TITLE
Change ACS rules file fix bug that left OPUS WCS keyword behind.

### DIFF
--- a/fitsblender/acs_header.rules
+++ b/fitsblender/acs_header.rules
@@ -347,6 +347,8 @@ XTENSION
 # WCS Related Keyword Rules
 #     These move any OPUS-generated WCS values to the table
 #
+RADESYSO
+WCSTYPEO
 WCSNAMEO
 WCSAXESO
 LONPOLEO


### PR DESCRIPTION
This change updates the RULES for ACS so that the following two WCS keywords are removed from the drizzle product and moved to the HEADERTAB:

RADESYSO
WCSTYPEO

Leaving these behind was causing problems when trying to run **tweakback** later.  

This is related to spacetelescope/drizzlepac#863 

Tested by creating drizzled products with the current rules and with the fix. The two different drizzled images had their header updated by running **tweakreg** and then running **tweakback**. The images created with the fixed rules did not contain the offending keywords and ran through **tweakback** cleanly.  

python = 3.8.12
drizzlepac = 3.3.1
fitsblender = 0.4.0