### PR TITLE
Remove all OPUS WCS keywords from HDRTAB definition

### DIFF
--- a/fitsblender/acs_header.rules
+++ b/fitsblender/acs_header.rules
@@ -343,30 +343,6 @@ WFCMPRSD
 WCSNAME
 WRTERR
 XTENSION
-#
-# WCS Related Keyword Rules
-#     These move any OPUS-generated WCS values to the table
-#
-WCSNAMEO
-WCSAXESO
-LONPOLEO
-LATPOLEO
-RESTFRQO
-RESTWAVO
-CD1_1O
-CD1_2O
-CD2_1O
-CD2_2O
-CDELT1O
-CDELT2O
-CRPIX1O
-CRPIX2O
-CRVAL1O
-CRVAL2O
-CTYPE1O
-CTYPE2O
-CUNIT1O
-CUNIT2O
 ################################################################################
 #
 # Header Keyword Rules


### PR DESCRIPTION
This actually removes all OPUS WCS related keywords from the HDRTAB definition for ACS drizzle products to address the problems reported in [Drizzlepac issue #863](https://github.com/spacetelescope/drizzlepac/issues/863).  It addresses the core
reason any OPUS WCS keywords were being left behind in the ACS headers to confuse tasks like **tweakback** and **tweakreg**. 

