### PR TITLE
Remove Python 2 syntax and adhere to PEP standards

### DIFF
--- a/fitsblender/blender.py
+++ b/fitsblender/blender.py
@@ -32,6 +32,7 @@ import numpy as np
 from numpy import ma
 from astropy.io import fits
 
+
 class _KeywordMapping:
     """
     A simple class to verify and store information about each mapping
@@ -170,8 +171,8 @@ def fitsblender(headers, spec):
       are masked out.
     """
     mappings = [_KeywordMapping(*x) for x in spec]
-    data = [[] for x in spec]
-    data_masks = [[] for x in spec]
+    data = [[] for _ in spec]
+    data_masks = [[] for _ in spec]
 
     # Read in data
     for header in headers:
@@ -208,7 +209,7 @@ def fitsblender(headers, spec):
                 if value is not None:
                     data[i].append(value)
 
-        if hdulist != None:
+        if hdulist is not None:
             hdulist.close()
 
     # Aggregate data into dictionary
@@ -235,7 +236,7 @@ def fitsblender(headers, spec):
     for i, mapping in enumerate(mappings):
         if mapping.agg_func is None:
             array = np.array(data[i])
-            if np.issubdtype(np.int32,array.dtype):
+            if np.issubdtype(np.int32, array.dtype):
                 # see about recasting as int32
                 if not np.any(array/(2**31 - 1) > 1.):
                     array = array.astype(np.int32)

--- a/fitsblender/tests/test_fitsblender.py
+++ b/fitsblender/tests/test_fitsblender.py
@@ -38,9 +38,12 @@ from numpy.testing import \
 import fitsblender
 
 ROOT_DIR = None
+
+
 def setup():
     global ROOT_DIR
     ROOT_DIR = os.path.dirname(__file__)
+
 
 def _test_fitsblender(files):
     spec = [
@@ -73,12 +76,14 @@ def _test_fitsblender(files):
     assert_almost_equal(d['crpix_last'], 420.0)
     assert_almost_equal(d['crpix_stddev'], 204.77012857239592)
 
+
 def test_filenames():
     files = [
         (x, 0) for x in glob.glob(os.path.join(ROOT_DIR, "*.fits"))]
     files.sort()
 
     _test_fitsblender(files)
+
 
 def test_header_objects():
     files = glob.glob(os.path.join(ROOT_DIR, "*.fits"))
@@ -87,6 +92,7 @@ def test_header_objects():
 
     _test_fitsblender(headers)
 
+
 def test_nospec():
     """
     Test that no header list and no spec doesn't raise an exception.
@@ -94,6 +100,7 @@ def test_nospec():
     d, t = fitsblender.fitsblender([], [])
     assert d == {}
     assert len(t) == 0
+
 
 def test_raise():
     def raises():
@@ -108,6 +115,7 @@ def test_raise():
     files.sort()
 
     assert_raises(ValueError, raises)
+
 
 def test_raise_table():
     def raises():

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(
     install_requires=[
         'astropy>=5.0.4',
         'numpy',
-        'six',
         'stsci.tools',
     ],
     extras_require={


### PR DESCRIPTION
These changes do not change any functionality or API, but instead remove any lingering syntax related to Python 2.x and updates much of the code to be more compatible with current PEP standards. 