### PR TITLE
remove usages of deprecated `codecov` package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         'test': [
             'pytest',
             'pytest-cov',
-            'codecov',
         ],
     },
     packages=find_packages(),


### PR DESCRIPTION
the `codecov` package is now deprecated and has been yanked from PyPI