### PR TITLE
remove usages of deprecated `codecov` package

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,9 +29,10 @@ steps:
 
 - script: |
     python -m pip install pytest pytest-azurepipelines
-    pytest --cov=./
-    coverage xml
-    codecov -t "$CODECOV"
+    pytest --cov=./ --cov-report=xml:coverage.xml --cov-report=term-missing
+    curl -Os https://uploader.codecov.io/latest/linux/codecov
+    chmod +x codecov
+    ./codecov -t "$CODECOV"
   displayName: 'pytest'
   env:
     CODECOV: $(codecov)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         'test': [
             'pytest',
             'pytest-cov',
-            'codecov',
         ],
     },
     packages=find_packages(),


### PR DESCRIPTION
the `codecov` package is now deprecated and has been yanked from PyPI